### PR TITLE
`Logger::debug` is deprecated

### DIFF
--- a/src/logger/src/LoggerFactory.php
+++ b/src/logger/src/LoggerFactory.php
@@ -20,6 +20,7 @@ use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\FormattableHandlerInterface;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\StreamHandler;
+use Monolog\Level;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -79,7 +80,7 @@ class LoggerFactory
         $handlerClass = Arr::get($config, 'handler.class', StreamHandler::class);
         $handlerConstructor = Arr::get($config, 'handler.constructor', [
             'stream' => BASE_PATH . '/runtime/logs/hyperf.log',
-            'level' => Logger::DEBUG,
+            'level' => Level::DEBUG,
         ]);
 
         return [


### PR DESCRIPTION
replace `Hyperf\Logger\Logger::debug` to `Monolog\Level::debug`